### PR TITLE
Ignore .babelrc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc


### PR DESCRIPTION
Mucks up the 'kangaroo' project when we include this (trying to reference a plugin that doesn't exist) so let's not include it in the published npm package. It will be included when you pull the source down from GitHub, as you need this file to build the standalone widget.