### PR TITLE
Stop user scrolling

### DIFF
--- a/src/js/elements/chat-section.js
+++ b/src/js/elements/chat-section.js
@@ -32,7 +32,7 @@ class ChatSection extends Element {
     super();
     this._create();
     widget.appendChild(this.self);
-    this.textKr = '';
+    this.textKr = EMPTY_STRING;
   }
 
   reset() {

--- a/src/js/elements/chat-section.js
+++ b/src/js/elements/chat-section.js
@@ -289,7 +289,7 @@ class ChatSection extends Element {
   }
 
   clearInputText(target, channelUrl) {
-    let items = target.querySelectorAll(this.tagName.DIV);
+    let items = target.querySelectorAll(this.tagType.DIV);
     for (var i = 0 ; i < items.length ; i++) {
       let item = items[i];
       item.remove();
@@ -581,7 +581,7 @@ class ChatSection extends Element {
   }
 
   createUserList(target) {
-    if (target.querySelectorAll(this.tagName.UL).length === 0) {
+    if (target.querySelectorAll(this.tagType.UL).length === 0) {
       let userList = this.createUl();
       target.list = userList;
       target.appendChild(userList);
@@ -589,23 +589,23 @@ class ChatSection extends Element {
   }
 
   createUserListItem(user) {
-    var li = this.createLi();
+    let li = this.createLi();
 
-    var userItem = this.createDiv();
+    let userItem = this.createDiv();
     this._setClass(userItem, [className.USER_ITEM]);
 
-    var userSelect = this.createDiv();
+    let userSelect = this.createDiv();
     this._setClass(userSelect, [className.USER_SELECT]);
     this._setDataset(userSelect, 'user-id', user.userId);
     li.select = userSelect;
     userItem.appendChild(userSelect);
 
-    var userProfile = this.createDiv();
+    let userProfile = this.createDiv();
     this._setClass(userProfile, [className.IMAGE]);
     this._setBackgroundImage(userProfile, user.profileUrl);
     userItem.appendChild(userProfile);
 
-    var userNickname = this.createDiv();
+    let userNickname = this.createDiv();
     this._setClass(userNickname, [className.NICKNAME]);
     this._setContent(userNickname, xssEscape(user.nickname));
     userItem.appendChild(userNickname);

--- a/src/js/elements/elements.js
+++ b/src/js/elements/elements.js
@@ -4,7 +4,7 @@ import { className, styleValue } from '../consts.js';
 
 class Element {
   constructor() {
-    this.tagName = {
+    this.tagType = {
       DIV: 'div',
       SPAN: 'span',
       INPUT: 'input',
@@ -30,43 +30,43 @@ class Element {
   Create Elements
    */
   createDiv() {
-    return document.createElement(this.tagName.DIV);
+    return document.createElement(this.tagType.DIV);
   }
 
   createTime() {
-    return document.createElement(this.tagName.TIME);
+    return document.createElement(this.tagType.TIME);
   }
 
   createA() {
-    return document.createElement(this.tagName.A);
+    return document.createElement(this.tagType.A);
   }
 
   createImg() {
-    return document.createElement(this.tagName.IMG);
+    return document.createElement(this.tagType.IMG);
   }
 
   createSpan() {
-    return document.createElement(this.tagName.SPAN);
+    return document.createElement(this.tagType.SPAN);
   }
 
   createLabel() {
-    return document.createElement(this.tagName.LABEL);
+    return document.createElement(this.tagType.LABEL);
   }
 
   createInput() {
-    return document.createElement(this.tagName.INPUT);
+    return document.createElement(this.tagType.INPUT);
   }
 
   createUl() {
-    return document.createElement(this.tagName.UL);
+    return document.createElement(this.tagType.UL);
   }
 
   createLi() {
-    return document.createElement(this.tagName.LI);
+    return document.createElement(this.tagType.LI);
   }
 
   createVideo() {
-    return document.createElement(this.tagName.VIDEO);
+    return document.createElement(this.tagType.VIDEO);
   }
 
   _setClass(...args) {

--- a/src/js/elements/list-board.js
+++ b/src/js/elements/list-board.js
@@ -119,7 +119,6 @@ class ListBoard extends Element {
       this.self.removeChild(this.listContent);
     }
     this._setContent(this.topTitle, TITLE_TOP_LOGIN);
-    hide(this.btnOption);
     hide(this.btnNewChat);
     this.self.appendChild(this.loginForm);
     this._toggleLoginBtn();
@@ -179,7 +178,6 @@ class ListBoard extends Element {
       this._cleanLoginForm();
     }
     this._setContent(this.topTitle, TITLE_TOP_CHANNEL);
-    show(this.btnOption);
     show(this.btnNewChat);
     this.self.appendChild(this.listContent);
   }

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -73,10 +73,11 @@ class SBWidget {
   }
 
   _initClickEvent(event) {
+    let _isReservedClass = (t) => {
+      return hasClass(t, className.IC_MEMBERS) || hasClass(t, className.IC_INVITE) || hasClass(t, className.IC_NEW_CHAT);
+    };
     let _checkPopup = function(_target, obj) {
-      if (obj === _target || hasClass(_target, className.IC_MEMBERS)
-                          || hasClass(_target, className.IC_INVITE)
-                          || hasClass(_target, className.IC_NEW_CHAT)) {
+      if (obj === _target || _isReservedClass(_target)) {
         return true;
       } else {
         let returnedCheck = false;

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -73,12 +73,14 @@ class SBWidget {
   }
 
   _initClickEvent(event) {
-    var _checkPopup = function(_target, obj) {
-      if (obj === _target || hasClass(_target, className.IC_MEMBERS) || hasClass(_target, className.IC_INVITE)) {
+    let _checkPopup = function(_target, obj) {
+      if (obj === _target || hasClass(_target, className.IC_MEMBERS)
+                          || hasClass(_target, className.IC_INVITE)
+                          || hasClass(_target, className.IC_NEW_CHAT)) {
         return true;
       } else {
-        var returnedCheck = false;
-        for (var i = 0 ; i < obj.childNodes.length ; i++) {
+        let returnedCheck = false;
+        for (let i = 0 ; i < obj.childNodes.length ; i++) {
           returnedCheck = _checkPopup(_target, obj.childNodes[i]);
           if (returnedCheck) break;
         }
@@ -446,6 +448,12 @@ class SBWidget {
         userContent.list.appendChild(item);
       }
     }
+
+    this.chatSection.addUserListScrollEvent(target, () => {
+      this.sb.getUserList((userList) => {
+        this.setUserList(target, userList);
+      });
+    });
   }
 
   getChannelList() {

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -446,11 +446,6 @@ class SBWidget {
         userContent.list.appendChild(item);
       }
     }
-    this.chatSection.addUserListScrollEvent(target, () => {
-      this.sb.getUserList((userList) => {
-        this.setUserList(target, userList);
-      });
-    });
   }
 
   getChannelList() {


### PR DESCRIPTION
# Things Done
- remove unused option
  - wasn't causing anything to break, just set to undefined
- fixed bug wherein the user list would be loaded twice if you scrolled down when initially creating a chat
- rename variable that means something special (`tagNames` to `tagTypes`) 

# How To Test
- spin up the widget
- click on the 'New Message' button
![screen shot 2018-03-05 at 10 55 55 am](https://user-images.githubusercontent.com/35499926/36984880-d76aac44-2063-11e8-83f9-adf7a1ab8bb6.png)

- ensure all the users are present while you scroll down the list
- ensure that, when you reach the bottom of the scroll, that the list of users aren't reloaded and creating duplicates
![screen shot 2018-03-05 at 10 55 11 am](https://user-images.githubusercontent.com/35499926/36984963-0cea4d5c-2064-11e8-94a6-60618f1c295e.png)

